### PR TITLE
Fix code block rendering after merge

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -48,9 +48,12 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+.chat-code-block .hljs {
+  background: transparent !important;
+}
+
 :root:not(.dark) .chat-code-block .hljs {
   color: #24292e;
-  background: transparent;
 }
 
 :root:not(.dark) .chat-code-block .hljs-doctag,
@@ -138,10 +141,6 @@
 :root:not(.dark) .chat-code-block .hljs-deletion {
   color: #b31d28;
   background-color: #ffeef0;
-}
-
-.dark .chat-code-block .hljs {
-  background: transparent;
 }
 
 .chat-code-scrollbar {
@@ -288,25 +287,33 @@
   .chat-page-scrollbar {
     scrollbar-gutter: stable;
     scrollbar-width: auto;
-    scrollbar-color: color-mix(in oklch, var(--muted-foreground) 55%, transparent)
-      color-mix(in oklch, var(--border) 75%, var(--background));
+    scrollbar-color: color-mix(in oklch, var(--muted-foreground) 55%, transparent) #f1f1f1;
   }
   .chat-page-scrollbar::-webkit-scrollbar {
     width: 16px;
     height: 16px;
   }
   .chat-page-scrollbar::-webkit-scrollbar-track {
-    background: color-mix(in oklch, var(--border) 75%, var(--background));
+    background: #f1f1f1;
   }
   .chat-page-scrollbar::-webkit-scrollbar-thumb {
     background: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
     background-clip: padding-box;
-    border: 4px solid color-mix(in oklch, var(--border) 75%, var(--background));
+    border: 4px solid #f1f1f1;
     border-radius: 999px;
   }
   .chat-page-scrollbar::-webkit-scrollbar-thumb:hover {
     background: var(--muted-foreground);
     background-clip: padding-box;
+  }
+  .dark .chat-page-scrollbar {
+    scrollbar-color: color-mix(in oklch, var(--muted-foreground) 55%, transparent) #1f1f1f;
+  }
+  .dark .chat-page-scrollbar::-webkit-scrollbar-track {
+    background: #1f1f1f;
+  }
+  .dark .chat-page-scrollbar::-webkit-scrollbar-thumb {
+    border-color: #1f1f1f;
   }
   .dark .sidebar-scrollbar {
     scrollbar-color: #2f2f2f transparent;

--- a/components/chat/code-block.tsx
+++ b/components/chat/code-block.tsx
@@ -121,7 +121,7 @@ export default function CodeBlock({ children, className, ...props }: Props) {
         {...props}
         className={cn(
           'chat-code-scrollbar max-h-[60vh] overflow-auto rounded-b-3xl bg-sidebar-accent px-0 pt-1 pb-3 text-[13px] leading-6 dark:bg-[#181818]',
-          '[&_code]:block [&_code]:bg-transparent [&_code]:!p-0 [&_code]:font-mono [&_code]:text-[13px] [&_code]:text-inherit',
+          '[&_code]:block [&_code]:!bg-transparent [&_code]:!p-0 [&_code]:font-mono [&_code]:text-[13px] [&_code]:text-inherit',
           '[&_code]:min-w-max [&_code]:!pr-5 [&_code]:!pl-5',
           className,
         )}


### PR DESCRIPTION
## Summary

Fix code block rendering issues introduced after the previous merge.

## Changes

- Restore the expected code block visual style
- Keep language label and copy action working
- Ensure code block rendering works correctly in light and dark mode
- Preserve existing markdown rendering behavior

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified code block rendering manually in the chat page